### PR TITLE
include source when building odk-tables-api

### DIFF
--- a/odk-tables-api/pom.xml
+++ b/odk-tables-api/pom.xml
@@ -52,6 +52,23 @@
         </plugin>
 
         <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                    <configuration>
+                        <includes>
+                            <include>**/odktables/rest/**</include>
+                        </includes>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+
+        <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
           <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <gwt.maven.plugin.version>2.7.0</gwt.maven.plugin.version>
         <maven.jar.plugin.version>2.6</maven.jar.plugin.version>
         <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
+        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
         <maven.war.plugin.version>2.6</maven.war.plugin.version>
         <maven.ear.plugin.version>2.10.1</maven.ear.plugin.version>
         <maven.antrun.plugin.version>1.8</maven.antrun.plugin.version>
@@ -812,6 +813,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven.javadoc.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven.source.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This allows us to include source of odk-tables-api in downstream projects.